### PR TITLE
Updated confirmation prompt

### DIFF
--- a/Invoke-BadShares.ps1
+++ b/Invoke-BadShares.ps1
@@ -35,12 +35,10 @@ function New-BadSharesRootDirectory {
             Write-Warning -Message "You need to confirm the action to use BadShares."
             break
         }
-
         if (Test-Path -Path $BadSharesPath) {
             Write-Warning "The directory '$BadSharesPath' already exists!"
             Write-Host "[i] If you continue, this script will overwrite: " -ForegroundColor Yellow -NoNewline
             Write-Host "$BadSharesPath" -ForegroundColor Cyan
-
             Write-Host "[i] Do you want to continue [Y] Yes "  -ForegroundColor Yellow -NoNewline
             Write-Host "[N] " -ForegroundColor Yellow -NoNewline
             Write-Host "No: "  -ForegroundColor Yellow -NoNewline

--- a/Invoke-BadShares.ps1
+++ b/Invoke-BadShares.ps1
@@ -1,37 +1,46 @@
-﻿function New-BadSharesRootDirectory {
-    [CmdletBinding()]
+function New-BadSharesRootDirectory {
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        ConfirmImpact = 'High'
+    )]
     param (
         [ValidateNotNullOrEmpty()]
         [string]$Root = "C:\",
 
         [ValidateNotNullOrEmpty()]
-        [string]$Name = "BadShares"
+        [string]$Name = "BadShares",
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.SwitchParameter]$Force
     )
 
     begin {
         $BadSharesRoot = $Root
         $BadSharesSharesDirectoryName = "BadShares"
         $BadSharesPath = "$BadSharesRoot$BadSharesSharesDirectoryName"
+
+        # Detecting if Confirm switch is used to bypass the confirmation prompts
+        if ($Force -and -Not $Confirm) {
+            $ConfirmPreference = 'None'
+        }
     }
 
     process {
-        Write-Host "If you continue, this script create several new folders and files." -ForegroundColor Yellow 
-        Write-Host "Do you want to continue [Y] Yes "  -ForegroundColor Yellow -NoNewline
-        Write-Host "[N] " -ForegroundColor Yellow -NoNewline
-        Write-Host "No: "  -ForegroundColor Yellow -NoNewline
-        $WarningError = ''
-        $WarningError = Read-Host
-        if ($WarningError -like 'y') {
-            Write-Host "`n[i] Beginning the BadShares setup process..."
-           
-        } else {
-            Write-Warning "You need to select y to use BadShares."
-            break;
+        # Prompt for confirmation before proceeding
+        if ($PSCmdlet.ShouldProcess('Your computer', 'Creating several new folders and files')) { 
+
+            Write-Host -Object "`n[i] Beginning the BadShares setup process..."
         }
+        else {
+            Write-Warning -Message "You need to confirm the action to use BadShares."
+            break
+        }
+
         if (Test-Path -Path $BadSharesPath) {
             Write-Warning "The directory '$BadSharesPath' already exists!"
             Write-Host "[i] If you continue, this script will overwrite: " -ForegroundColor Yellow -NoNewline
             Write-Host "$BadSharesPath" -ForegroundColor Cyan
+
             Write-Host "[i] Do you want to continue [Y] Yes "  -ForegroundColor Yellow -NoNewline
             Write-Host "[N] " -ForegroundColor Yellow -NoNewline
             Write-Host "No: "  -ForegroundColor Yellow -NoNewline


### PR DESCRIPTION
Used native PowerShell's confirmation prompt. It can be used other places in the script where confirmation prompt is required :)

Now the prompt for confirmation can be confirmed like this, maybe for unattended operation

```powershell
New-BadSharesRootDirectory -Force
```

otherwise it will be shown to the user.
